### PR TITLE
Updating image to d39fe9

### DIFF
--- a/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 - ../../base/
 images:
 - name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
-  newTag: 8365dc
+  newTag: d39fe9


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:d39fe9 on gitops-demo/simple-quarkus-service-deploy/app/overlays/prod