### PR TITLE
Updating image to 42d45f

### DIFF
--- a/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
+++ b/gitops-demo/simple-quarkus-service-deploy/app/overlays/prod/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 - ../../base/
 images:
 - name: image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service
-  newTag: 49b0b3
+  newTag: 42d45f


### PR DESCRIPTION
Updating image to image-registry.openshift-image-registry.svc:5000/simple-quarkus-pipeline/simple-quarkus-service:42d45f on gitops-demo/simple-quarkus-service-deploy/app/overlays/prod